### PR TITLE
Add bench New, Open, Save-as

### DIFF
--- a/src/K0x.Workbench.DataStorage.Abstractions/IBenchFilePathProvider.cs
+++ b/src/K0x.Workbench.DataStorage.Abstractions/IBenchFilePathProvider.cs
@@ -2,5 +2,5 @@
 
 public interface IBenchFilePathProvider
 {
-    string FilePath { get; set; }
+    string? FilePath { get; set; }
 }

--- a/src/K0x.Workbench.DataStorage.JsonFiles/BenchFilePathProvider.cs
+++ b/src/K0x.Workbench.DataStorage.JsonFiles/BenchFilePathProvider.cs
@@ -4,5 +4,5 @@ namespace K0x.Workbench.DataStorage.JsonFiles;
 
 public class BenchFilePathProvider : IBenchFilePathProvider
 {
-    public string FilePath { get; set; } = string.Empty;
+    public string? FilePath { get; set; }
 }

--- a/src/WpfBlazor/PocPage.razor
+++ b/src/WpfBlazor/PocPage.razor
@@ -10,6 +10,12 @@
 
 <p>Bench File Path: @(BenchFilePathProvider.FilePath ?? "null")</p>
 
+<button class="btn btn-primary" @onclick="NewSampleBenchFileAsnyc">New Sample Bench File...</button>
+
+<button class="btn btn-primary" @onclick="OpenBenchFileAsnyc">Open...</button>
+
+<button class="btn btn-primary" @onclick="SaveAsBenchFileAsnyc">Save As...</button>
+
 @if (Bench != null)
 {
     <BenchView Bench=Bench />

--- a/src/WpfBlazor/PocPage.razor.cs
+++ b/src/WpfBlazor/PocPage.razor.cs
@@ -1,6 +1,7 @@
 using K0x.Workbench.DataStorage.Abstractions;
 using K0x.Workbench.DataStorage.Abstractions.Models;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Windows;
@@ -21,20 +22,92 @@ public partial class PocPage : ComponentBase
     {
         Logger.LogTrace("OnInitialized START.");
 
-        // AppSetting1 = Configuration["AppSettings:Setting1"] ?? "Setting1 Not Found";
-
-        await LoadBenchFromJsonFileAsync();
+        if (!string.IsNullOrEmpty(BenchFilePathProvider.FilePath))
+        {
+            Bench = await LoadBenchFromJsonFileAsync(BenchFilePathProvider.FilePath);
+        }
 
         Logger.LogTrace("OnInitialized END.");
     }
 
-    private async Task LoadBenchFromJsonFileAsync()
+    private async Task OpenBenchFileAsnyc(MouseEventArgs e)
+    {
+        Microsoft.Win32.OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog();
+        dialog.FileName = "K0x Bench Sample 1"; // Default file name
+        dialog.DefaultExt = ".json"; // Default file extension
+        dialog.Filter = "JSON documents (.json)|*.json"; // Filter files by extension
+
+        bool? result = dialog.ShowDialog();
+
+        if (result is true)
+        {
+            Bench? bench = await LoadBenchFromJsonFileAsync(dialog.FileName);
+
+            if (bench is not null)
+            {
+                BenchFilePathProvider.FilePath = dialog.FileName;
+
+                Bench = bench;
+            }
+        }
+    }
+    private async Task NewSampleBenchFileAsnyc(MouseEventArgs e)
+    {
+        var dialog = new Microsoft.Win32.SaveFileDialog();
+        dialog.FileName = "K0x Bench Sample 1"; // Default file name
+        dialog.DefaultExt = ".json"; // Default file extension
+        dialog.Filter = "JSON documents (.json)|*.json"; // Filter files by extension
+
+        bool? result = dialog.ShowDialog();
+
+        if (result is true)
+        {
+            BenchFilePathProvider.FilePath = dialog.FileName;
+
+            Bench sampleBench = CreateSampleBench();
+
+            await SaveBenchFileAsync(sampleBench, dialog.FileName);
+
+            BenchFilePathProvider.FilePath = dialog.FileName;
+
+            Bench = sampleBench;
+        }
+    }
+
+    private async Task SaveAsBenchFileAsnyc(MouseEventArgs e)
+    {
+        if (Bench is null)
+        {
+            MessageBox.Show(
+                "No bench to save.",
+                caption: "No bench to save.",
+                button: MessageBoxButton.OK,
+                icon: MessageBoxImage.Information);
+            return;
+        }
+
+        var dialog = new Microsoft.Win32.SaveFileDialog();
+        dialog.FileName = BenchFilePathProvider.FilePath; // Default file name to current file path.
+        dialog.DefaultExt = ".json"; // Default file extension
+        dialog.Filter = "JSON documents (.json)|*.json"; // Filter files by extension
+
+        bool? result = dialog.ShowDialog();
+
+        if (result is true)
+        {
+            await SaveBenchFileAsync(Bench, dialog.FileName);
+
+            BenchFilePathProvider.FilePath = dialog.FileName;
+        }
+    }
+
+    private async Task<Bench?> LoadBenchFromJsonFileAsync(string jsonFilePath)
     {
         try
         {
-            await CreateBenchFileIfNotExistAsync(BenchFilePathProvider.FilePath);
+            Bench bench = await BenchFileLoader.LoadAsync(jsonFilePath);
 
-            Bench = await BenchFileLoader.LoadAsync(BenchFilePathProvider.FilePath);
+            return bench;
         }
         catch (Exception ex)
         {
@@ -42,9 +115,7 @@ public partial class PocPage : ComponentBase
 
             MessageBox.Show(
                 "An error occurred loading the bench from JSON file.\n"
-                + $"Path: {BenchFilePathProvider.FilePath}\n"
-                + "\n"
-                + "The application cannot be started.\n"
+                + $"Path: {jsonFilePath}\n"
                 + "\n"
                 + $"{ex.GetType()}\n"
                 + "\n"
@@ -53,51 +124,60 @@ public partial class PocPage : ComponentBase
                 button: MessageBoxButton.OK,
                 icon: MessageBoxImage.Error);
 
-            throw;
+            return null;
         }
     }
 
-    private async Task CreateBenchFileIfNotExistAsync(string jsonFilePath)
+    private static Bench CreateSampleBench()
+    {
+        return new Bench
+        {
+            Label = "K0x-workbench Sample Bench",
+            Kits = new List<Kit>
+                {
+                    new Kit
+                    {
+                        Label = "Workspace Kit",
+                        Tools = new List<Tool>
+                        {
+                            new Tool { Label = "File Explorer", Command = "C:/_BkGit/bryanknox/k0x-workbench" },
+                            new Tool { Label = "Tool 1.2", Command = "cmd2" }
+                        }
+                    },
+                    new Kit
+                    {
+                        Label = "Kit 2",
+                        Tools = new List<Tool>
+                        {
+                            new Tool { Label = "Tool 2.1", Command = "cmd3" },
+                            new Tool { Label = "Tool 2.2", Command = "cmd4" }
+                        }
+                    }
+                }
+        };
+    }
+
+    private async Task SaveBenchFileAsync(Bench bench, string jsonFilePath)
     {
         try
         {
-            var isExist = System.IO.File.Exists(jsonFilePath);
-            if (!isExist)
-            {
-                var bench = new Bench
-                {
-                    Label = "PoC k0x-workbench Bench",
-                    Kits = new List<Kit>
-                    {
-                        new Kit
-                        {
-                            Label = "Workspace",
-                            Tools = new List<Tool>
-                            {
-                                new Tool { Label = "File Explorer", Command = "C:/_BkGit/bryanknox/k0x-workbench" },
-                                new Tool { Label = "Tool 1.2", Command = "cmd2" }
-                            }
-                        },
-                        new Kit
-                        {
-                            Label = "Kit 2",
-                            Tools = new List<Tool>
-                            {
-                                new Tool { Label = "Tool 2.1", Command = "cmd3" },
-                                new Tool { Label = "Tool 2.2", Command = "cmd4" }
-                            }
-                        }
-                    }
-                };
-
-                await BenchFileSaver.SaveAsync(bench, "poc-bench.json");
-            }
+            await BenchFileSaver.SaveAsync(bench, jsonFilePath);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, $"{nameof(CreateBenchFileIfNotExistAsync)} Error.");
-            throw;
-        }
+            Logger.LogError(ex, $"{nameof(SaveBenchFileAsync)} Error.");
 
+            MessageBox.Show(
+                "An error occurred saving the bench to JSON file.\n"
+                + $"Path: {jsonFilePath}\n"
+                + "\n"
+                + $"{ex.GetType()}\n"
+                + "\n"
+                + $"{ex.Message}\n",
+                caption: "Error saving the bench to JSON file.",
+                button: MessageBoxButton.OK,
+                icon: MessageBoxImage.Error);
+        }
     }
+
 }

--- a/src/WpfBlazor/Program.cs
+++ b/src/WpfBlazor/Program.cs
@@ -61,7 +61,7 @@ public class Program
     static void InitBenchFilePathProviderFromArgs(IServiceProvider serviceProvider, string[] args)
     {
         // Get the file path or use the default.
-        string benchJsonFilePath = "poc-bench.json";
+        string? benchJsonFilePath = null;
         if (args.Length > 0 && !string.IsNullOrWhiteSpace(args[0]))
         {
             benchJsonFilePath = args[0];

--- a/tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileLoaderTests/LoadAsyncTests.cs
+++ b/tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileLoaderTests/LoadAsyncTests.cs
@@ -15,7 +15,7 @@ public class LoadAsyncTests
         var expectedBench = new Bench
         {
             Label = "Test Bench",
-            Kit = new List<Kit>
+            Kits = new List<Kit>
             {
                 new Kit
                 {

--- a/tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileSaverTests/SaveAsyncTests.cs
+++ b/tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileSaverTests/SaveAsyncTests.cs
@@ -24,7 +24,7 @@ public class SaveAsyncTests
         var bench = new Bench
         {
             Label = "Test Bench",
-            Kit = new List<Kit>
+            Kits = new List<Kit>
             {
                 new Kit
                 {


### PR DESCRIPTION
Update bench file handling and UI enhancements

- Allow nullable `FilePath` in `IBenchFilePathProvider` and `BenchFilePathProvider`.
- Add buttons in `PocPage.razor` for creating, opening, and saving bench files.
- Add methods in `PocPage.razor.cs` for file operations: `OpenBenchFileAsync`, `NewSampleBenchFileAsync`, `SaveAsBenchFileAsync`, `LoadBenchFromJsonFileAsync`, `CreateSampleBench`, and `SaveBenchFileAsync`.
- Update `OnInitializedAsync` in `PocPage.razor.cs` to load bench file only if `FilePath` is not null or empty.
- Make `benchJsonFilePath` nullable in `Program.cs`.
- Fix tests by Renaming
This pull request introduces several important changes to the `WpfBlazor` project, focusing on improving the handling of bench file paths, adding new functionalities to the UI, and updating test cases. The most significant changes include making the `FilePath` property nullable, adding new buttons and their respective functionalities to the UI, and updating test cases to reflect these changes.

### Nullable FilePath Property:

* [`src/K0x.Workbench.DataStorage.Abstractions/IBenchFilePathProvider.cs`](diffhunk://#diff-a13b2749d2d078bbb47592d1db1712ffe2fae64cbb59738ce586353f6d19c662L5-R5): Changed `FilePath` property to be nullable.
* [`src/K0x.Workbench.DataStorage.JsonFiles/BenchFilePathProvider.cs`](diffhunk://#diff-fffd85bf635ee506ceb279594c6cbea54f98c60eec476b7605844535bf5df8e8L7-R7): Updated `FilePath` property to be nullable.

### UI Enhancements:

* [`src/WpfBlazor/PocPage.razor`](diffhunk://#diff-53d0a31d93418b16e7cb3eb6a312b74f8e7f3578373c2db058f9fbf67f790eedR13-R18): Added new buttons for "New Sample Bench File", "Open", and "Save As" functionalities.

### Functional Changes:

* [`src/WpfBlazor/PocPage.razor.cs`](diffhunk://#diff-5a6c57f43ad6dad1cef493913c59e742e3755634330dca63b013ed2032bd3535L24-R118): Implemented new methods `NewSampleBenchFileAsnyc`, `OpenBenchFileAsnyc`, and `SaveAsBenchFileAsnyc` for handling bench file operations. [[1]](diffhunk://#diff-5a6c57f43ad6dad1cef493913c59e742e3755634330dca63b013ed2032bd3535L24-R118) [[2]](diffhunk://#diff-5a6c57f43ad6dad1cef493913c59e742e3755634330dca63b013ed2032bd3535L56-R140) [[3]](diffhunk://#diff-5a6c57f43ad6dad1cef493913c59e742e3755634330dca63b013ed2032bd3535L92-R182)

### Configuration Updates:

* [`src/WpfBlazor/Program.cs`](diffhunk://#diff-7518f6db31aff37ddd691ba089c068effe928be16dc02fef21a5080eb4d24872L64-R64): Updated default bench file path initialization to handle nullable values.

### Test Case Updates:

* [`tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileLoaderTests/LoadAsyncTests.cs`](diffhunk://#diff-da5a2ed646b95d5d02d9602b70ccd8ebaed4986ad298f99610a4aaea8c4af714L18-R18): Corrected property name from `Kit` to `Kits`.
* [`tests/K0x.Workbench.DataStorage.JsonFiles.Tests/BenchJsonFileSaverTests/SaveAsyncTests.cs`](diffhunk://#diff-387e773937264987c4936b8e9c87688e21243978775c5e82880e80e5ddf36477L27-R27): Corrected property name from `Kit` to `Kits`. `Kit` to `Kits` in `LoadAsyncTests.cs` and `SaveAsyncTests.cs`.