### PR TITLE
Add arguments for StartProcessInfo

### DIFF
--- a/src/K0x.Workbench.DataStorage.Abstractions/Models/Tool.cs
+++ b/src/K0x.Workbench.DataStorage.Abstractions/Models/Tool.cs
@@ -4,5 +4,6 @@ public record Tool
 {
     public string Label { get; init; } = string.Empty;
     public required string Command { get; init; }
-    public string? WorkingDirectory { get; init; } = null;
+    public string? Arguments { get; init; }
+    public string? WorkingDirectory { get; init; }
 }

--- a/src/WpfBlazor/Components/ToolView.razor
+++ b/src/WpfBlazor/Components/ToolView.razor
@@ -7,7 +7,12 @@
 <div>
     <button class="btn btn-primary" @onclick="Execute">@Tool.Label</button>
     <p> @Tool.Command </p>
-    @if (Tool.WorkingDirectory is not null)
+    @if (string.IsNullOrEmpty(Tool.Arguments) is false)
+    {
+        <p>Arguments:</p> @(Tool.Arguments ?? "null")
+    }
+
+    @if (string.IsNullOrEmpty(Tool.WorkingDirectory) is false)
     {
         <p>Working Directory:</p> @(Tool.WorkingDirectory ?? "null")
     }
@@ -22,7 +27,9 @@
         var psi = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = Tool.Command,
+                Arguments = Tool.Arguments,
                 WorkingDirectory = Tool.WorkingDirectory,
+                ErrorDialog = true,
                 UseShellExecute = true,
             };
         try {


### PR DESCRIPTION
This pull request introduces changes to the `Tool` model and updates the `ToolView` component to handle the new `Arguments` property. The most important changes include adding the `Arguments` property to the `Tool` model and updating the `ToolView` component to display and use this new property.

Changes to `Tool` model:

* [`src/K0x.Workbench.DataStorage.Abstractions/Models/Tool.cs`](diffhunk://#diff-6f8e74f84f8c19af090dc5cb85140e1cff222cad873162eb3b70d51b0f3ffd88L7-R8): Added the `Arguments` property to the `Tool` model.

Updates to `ToolView` component:

* [`src/WpfBlazor/Components/ToolView.razor`](diffhunk://#diff-66da4016f640e352342c33888012f522f1080f6f6554616314a6c880d9585234L10-R15): Updated the view to display the `Arguments` property if it is not null or empty.
* [`src/WpfBlazor/Components/ToolView.razor`](diffhunk://#diff-66da4016f640e352342c33888012f522f1080f6f6554616314a6c880d9585234R30-R32): Modified the process start information to include the `Arguments` property when executing the tool command.