### PR TITLE
Don't scroll on tool execute

### DIFF
--- a/src/WpfBlazor/Components/ToolView.razor
+++ b/src/WpfBlazor/Components/ToolView.razor
@@ -5,7 +5,7 @@
 @inject ILogger<ToolView> Logger
 
 <div>
-    <a href="#" @onclick="Execute">@Tool.Label</a>
+    <a href="#" @onclick="Execute" @onclick:preventDefault>@Tool.Label</a>
     <span class="text-line">@Tool.Command</span>
     @if (!string.IsNullOrEmpty(Tool.Arguments))
     {


### PR DESCRIPTION
**Problem:** Clicking tool causes the page to scroll back to the top

It looks like the page is being reloaded when the anchor link is clicked.

src\WpfBlazor\Components\ToolView.razor

```html
<a href="#" @onclick="Execute">@Tool.Label</a>

```

**Fix:** set the preventDefault attribute on the click even handler

```html
<a href="#" @onclick="Execute" @onclick:preventDefault>@Tool.Label</a>

```

**Thanks StackOverflow!**
[PreventDefault on Blazor input - Stack Overflow](https://stackoverflow.com/questions/55328157/preventdefault-on-blazor-input)
	https://stackoverflow.com/a/69915837/575113

	https://learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?view=aspnetcore-6.0#prevent-default-actions