### PR TITLE
Collapsed Tool details

### DIFF
--- a/src/WpfBlazor/Components/ToolView.razor
+++ b/src/WpfBlazor/Components/ToolView.razor
@@ -5,22 +5,36 @@
 @inject ILogger<ToolView> Logger
 
 <div>
-    <a href="#" @onclick="Execute" @onclick:preventDefault>@Tool.Label</a>
-    <span class="text-line">@Tool.Command</span>
-    @if (!string.IsNullOrEmpty(Tool.Arguments))
-    {
-        <span class="text-line indent">@Tool.Arguments</span>
-    }
 
-    @if (!string.IsNullOrEmpty(Tool.WorkingDirectory))
+    <span class="bi @expanderIconClass"
+        aria-hidden="true"
+        style="cursor:pointer"
+        @onclick="() => IsExpanded = !IsExpanded">&nbsp;</span>
+
+    <a href="#" @onclick="Execute" @onclick:preventDefault>@Tool.Label</a>
+
+    @if (IsExpanded)
     {
-        <span class="text-line">Working Directory: @Tool.WorkingDirectory</span>
+        <span class="text-line indent1">@Tool.Command</span>
+        @if (!string.IsNullOrEmpty(Tool.Arguments))
+        {
+            <span class="text-line indent2">@Tool.Arguments</span>
+        }
+
+        @if (!string.IsNullOrEmpty(Tool.WorkingDirectory))
+        {
+            <span class="text-line indent1">Working Directory: @Tool.WorkingDirectory</span>
+        }
     }
 </div>
 
 @code {
     [Parameter]
     public Tool Tool { get; set; } = default!;
+
+    private bool IsExpanded { get; set; } = false;
+
+    private string expanderIconClass => IsExpanded ? "bi-caret-down" : "bi-caret-right";
 
     private void Execute(MouseEventArgs e)
     {

--- a/src/WpfBlazor/Components/ToolView.razor.css
+++ b/src/WpfBlazor/Components/ToolView.razor.css
@@ -11,8 +11,12 @@ p {
     color: gray;
 }
 
-.indent {
-    margin-left: 20px; /* Adjust the value as needed */
+.indent1 {
+    margin-left: 25px; /* Adjust the value as needed */
+}
+
+.indent2 {
+    margin-left: 45px; /* Should be > indent1 */
 }
 
 .text-line {


### PR DESCRIPTION
Details of each tool are collapsed (hidden) by default, and can be seen or hidden by toggling the caret to the left of the tool label.