### PR TITLE
Add Internal namespace for RecentBenches storage

### DIFF
--- a/src/K0x.Workbench.RecentBenches/Internal/AppExeFolderPathProvider.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/AppExeFolderPathProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace K0x.Workbench.RecentBenches;
+﻿namespace K0x.Workbench.RecentBenches.Internal;
 
 public class AppExeFolderPathProvider : IAppExeFolderPathProvider
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/IAppExeFolderPathProvider.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/IAppExeFolderPathProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace K0x.Workbench.RecentBenches
+﻿namespace K0x.Workbench.RecentBenches.Internal
 {
     public interface IAppExeFolderPathProvider
     {

--- a/src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileLoader.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileLoader.cs
@@ -1,6 +1,6 @@
 using K0x.Workbench.RecentBenches.Abstractions.Models;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public interface IRecentBenchesJsonFileLoader
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileSaver.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileSaver.cs
@@ -1,6 +1,6 @@
 using K0x.Workbench.RecentBenches.Abstractions.Models;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public interface IRecentBenchesJsonFileSaver
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFileModel.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFileModel.cs
@@ -1,6 +1,6 @@
 ﻿using K0x.Workbench.RecentBenches.Abstractions.Models;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public class RecentBenchesFileModel
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFilePathProvider.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFilePathProvider.cs
@@ -1,7 +1,7 @@
 ﻿using K0x.Workbench.RecentBenches.Abstractions;
 using Microsoft.Extensions.Configuration;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public class RecentBenchesFilePathProvider : IRecentBenchesFilePathProvider
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileLoader.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileLoader.cs
@@ -2,7 +2,7 @@
 using K0x.Workbench.RecentBenches.Abstractions.Models;
 using System.IO.Abstractions;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public class RecentBenchesJsonFileLoader : IRecentBenchesJsonFileLoader
 {

--- a/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileSaver.cs
+++ b/src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileSaver.cs
@@ -1,7 +1,7 @@
 ﻿using K0x.DataStorage.JsonFiles;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
 
-namespace K0x.Workbench.RecentBenches;
+namespace K0x.Workbench.RecentBenches.Internal;
 
 public class RecentBenchesJsonFileSaver : IRecentBenchesJsonFileSaver
 {

--- a/src/K0x.Workbench.RecentBenches/RecentBenchAdder.cs
+++ b/src/K0x.Workbench.RecentBenches/RecentBenchAdder.cs
@@ -1,5 +1,6 @@
 ﻿using K0x.Workbench.RecentBenches.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
+using K0x.Workbench.RecentBenches.Internal;
 
 namespace K0x.Workbench.RecentBenches;
 

--- a/src/K0x.Workbench.RecentBenches/ServicesConfigurationExtensions.cs
+++ b/src/K0x.Workbench.RecentBenches/ServicesConfigurationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using K0x.DataStorage.JsonFiles;
 using K0x.Workbench.RecentBenches.Abstractions;
+using K0x.Workbench.RecentBenches.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO.Abstractions;
 

--- a/tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileLoaderTests/LoadAsyncTests.cs
+++ b/tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileLoaderTests/LoadAsyncTests.cs
@@ -1,11 +1,12 @@
 using FluentAssertions;
 using K0x.DataStorage.JsonFiles;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
+using K0x.Workbench.RecentBenches.Internal;
 using Moq;
 using System.IO.Abstractions.TestingHelpers;
 using Xunit;
 
-namespace K0x.Workbench.RecentBenches.Tests.RecentBenchesJsonFileLoaderTests;
+namespace K0x.Workbench.RecentBenches.Tests.Internal.RecentBenchesJsonFileLoaderTests;
 
 public class LoadAsyncTests
 {

--- a/tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileSaverTests/SaveAsyncTests.cs
+++ b/tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileSaverTests/SaveAsyncTests.cs
@@ -1,9 +1,10 @@
 using K0x.DataStorage.JsonFiles;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
+using K0x.Workbench.RecentBenches.Internal;
 using Moq;
 using Xunit;
 
-namespace K0x.Workbench.RecentBenches.Tests.RecentBenchesJsonFileSaverTests;
+namespace K0x.Workbench.RecentBenches.Tests.Internal.RecentBenchesJsonFileSaverTests;
 
 public class SaveAsyncTests
 {

--- a/tests/K0x.Workbench.RecentBenches.Tests/K0x.Workbench.RecentBenches.Tests.csproj
+++ b/tests/K0x.Workbench.RecentBenches.Tests/K0x.Workbench.RecentBenches.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />

--- a/tests/K0x.Workbench.RecentBenches.Tests/RecentBenchAdderTests/AddRecentBenchAsyncTests.cs
+++ b/tests/K0x.Workbench.RecentBenches.Tests/RecentBenchAdderTests/AddRecentBenchAsyncTests.cs
@@ -1,8 +1,9 @@
 using K0x.Workbench.RecentBenches.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
+using K0x.Workbench.RecentBenches.Internal;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
-using Microsoft.Extensions.Time.Testing;
 
 namespace K0x.Workbench.RecentBenches.Tests.RecentBenchAdderTests;
 

--- a/tests/K0x.Workbench.RecentBenches.Tests/RecentBenchesFilePathProviderTests/GetFilePathTests.cs
+++ b/tests/K0x.Workbench.RecentBenches.Tests/RecentBenchesFilePathProviderTests/GetFilePathTests.cs
@@ -1,8 +1,8 @@
 using FluentAssertions;
+using K0x.Workbench.RecentBenches.Internal;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
-using K0x.Workbench.RecentBenches.Abstractions;
 
 namespace K0x.Workbench.RecentBenches.Tests.RecentBenchesFilePathProviderTests;
 


### PR DESCRIPTION
Move  classes and interfaces that are only used internally in the `K0x.Workbench.RecentBenches` project into an `Internal` namespace. This is done to better organize the code and encapsulate internal implementation details.

Namespace modifications and file renaming:

* `src/K0x.Workbench.RecentBenches/AppExeFolderPathProvider.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/AppExeFolderPathProvider.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/IAppExeFolderPathProvider.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/IAppExeFolderPathProvider.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/IRecentBenchesJsonFileLoader.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileLoader.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/IRecentBenchesJsonFileSaver.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/IRecentBenchesJsonFileSaver.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/RecentBenchesFileModel.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFileModel.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.

Additional namespace changes:

* `src/K0x.Workbench.RecentBenches/RecentBenchesFilePathProvider.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/RecentBenchesFilePathProvider.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/RecentBenchesJsonFileLoader.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileLoader.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.
* `src/K0x.Workbench.RecentBenches/RecentBenchesJsonFileSaver.cs` renamed to `src/K0x.Workbench.RecentBenches/Internal/RecentBenchesJsonFileSaver.cs` and namespace changed to `K0x.Workbench.RecentBenches.Internal`.

Test project updates:

* `tests/K0x.Workbench.RecentBenches.Tests/RecentBenchesJsonFileLoaderTests/LoadAsyncTests.cs` renamed to `tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileLoaderTests/LoadAsyncTests.cs` and namespace changed to `K0x.Workbench.RecentBenches.Tests.Internal.RecentBenchesJsonFileLoaderTests`.
* `tests/K0x.Workbench.RecentBenches.Tests/RecentBenchesJsonFileSaverTests/SaveAsyncTests.cs` renamed to `tests/K0x.Workbench.RecentBenches.Tests/Internal/RecentBenchesJsonFileSaverTests/SaveAsyncTests.cs` and namespace changed to `K0x.Workbench.RecentBenches.Tests.Internal.RecentBenchesJsonFileSaverTests`.
* Added `K0x.Workbench.RecentBenches.Internal` namespace to `tests/K0x.Workbench.RecentBenches.Tests/RecentBenchAdderTests/AddRecentBenchAsyncTests.cs`.
* Added `K0x.Workbench.RecentBenches.Internal` namespace to `tests/K0x.Workbench.RecentBenches.Tests/RecentBenchesFilePathProviderTests/GetFilePathTests.cs`.