### PR TITLE
Enhance RecentPage to display RecentBench items

### DIFF
--- a/src/WpfBlazor/Components/RecentBenchView.razor
+++ b/src/WpfBlazor/Components/RecentBenchView.razor
@@ -1,0 +1,39 @@
+@using K0x.Workbench.DataStorage.Abstractions
+@using K0x.Workbench.RecentBenches.Abstractions.Models
+@using Microsoft.Extensions.Logging
+@using System.Windows
+@namespace WpfBlazor.Components
+@inject ILogger<ToolView> Logger
+@inject NavigationManager NavigationManager
+@inject IBenchFilePathProvider BenchFilePathProvider
+
+<div>
+    <span class="bi @expanderIconClass"
+        aria-hidden="true"
+        style="cursor:pointer"
+        @onclick="() => IsExpanded = !IsExpanded">&nbsp;</span>
+
+    <a href="#" @onclick="Execute" @onclick:preventDefault>@RecentBench.BenchLabel</a>
+
+    @if (IsExpanded)
+    {
+        <span class="text-line indent1">@RecentBench.FilePath</span>
+    }
+
+</div>
+
+@code {
+
+    [Parameter]
+    public RecentBench RecentBench { get; set; } = default!;
+
+    private bool IsExpanded { get; set; } = true;
+
+    private string expanderIconClass => IsExpanded ? "bi-caret-down" : "bi-caret-right";
+
+    private void Execute(MouseEventArgs e)
+    {
+        BenchFilePathProvider.FilePath = RecentBench.FilePath;
+        NavigationManager.NavigateTo("/bench");
+    }
+}

--- a/src/WpfBlazor/Components/RecentBenchView.razor
+++ b/src/WpfBlazor/Components/RecentBenchView.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Extensions.Logging
 @using System.Windows
 @namespace WpfBlazor.Components
-@inject ILogger<ToolView> Logger
+@inject ILogger<RecentBenchView> Logger
 @inject NavigationManager NavigationManager
 @inject IBenchFilePathProvider BenchFilePathProvider
 
@@ -13,7 +13,7 @@
         style="cursor:pointer"
         @onclick="() => IsExpanded = !IsExpanded">&nbsp;</span>
 
-    <a href="#" @onclick="Execute" @onclick:preventDefault>@RecentBench.BenchLabel</a>
+    <a href="#" @onclick="OnRecentBenchClick" @onclick:preventDefault>@RecentBench.BenchLabel</a>
 
     @if (IsExpanded)
     {
@@ -31,8 +31,9 @@
 
     private string expanderIconClass => IsExpanded ? "bi-caret-down" : "bi-caret-right";
 
-    private void Execute(MouseEventArgs e)
+    private void OnRecentBenchClick(MouseEventArgs e)
     {
+        Logger.LogInformation("OnRecentBenchClick: {RecentBench}", RecentBench);
         BenchFilePathProvider.FilePath = RecentBench.FilePath;
         NavigationManager.NavigateTo("/bench");
     }

--- a/src/WpfBlazor/Components/RecentBenchView.razor.css
+++ b/src/WpfBlazor/Components/RecentBenchView.razor.css
@@ -1,0 +1,26 @@
+a {
+    text-decoration: underline;
+}
+
+div {
+    margin-bottom: 5px;
+}
+
+p {
+    font-size: smaller;
+    color: gray;
+}
+
+.indent1 {
+    margin-left: 25px; /* Adjust the value as needed */
+}
+
+.indent2 {
+    margin-left: 45px; /* Should be > indent1 */
+}
+
+.text-line {
+    display: block;
+    font-size: smaller;
+    color: gray;
+}

--- a/src/WpfBlazor/Pages/RecentPage.razor
+++ b/src/WpfBlazor/Pages/RecentPage.razor
@@ -17,12 +17,23 @@ else if (RecentBenches.Count == 0)
 }
 else
 {
-    <ul>
-        @foreach (var bench in RecentBenches)
-        {
-            <RecentBenchView RecentBench="bench" />
-        }
-    </ul>
-}
 
-<button class="btn btn-primary" @onclick="RefreshRecentBenches">Refresh</button>
+    <hr class="horizontal-separator" />
+
+    <div>
+        <span class="bench-path">
+            Recent Benches file: @(RecentBenchesFilePathProvider.GetFilePath() ?? "null")
+            <i class="bi bi-pencil action-icon" @onclick="EditRecentBenchesFile" title="Edit Recent Benches file"></i>
+            <i class="bi bi-arrow-repeat action-icon" @onclick="ReloadRecentBenches" title="Reload Recent Benches file"></i>
+        </span>
+    </div>
+
+    <div>
+        <ul>
+            @foreach (var bench in RecentBenches)
+            {
+                <RecentBenchView RecentBench="bench" />
+            }
+        </ul>
+    </div>
+}

--- a/src/WpfBlazor/Pages/RecentPage.razor
+++ b/src/WpfBlazor/Pages/RecentPage.razor
@@ -23,8 +23,8 @@ else
     <div>
         <span class="bench-path">
             Recent Benches file: @(RecentBenchesFilePathProvider.GetFilePath() ?? "null")
-            <i class="bi bi-pencil action-icon" @onclick="EditRecentBenchesFile" title="Edit Recent Benches file"></i>
-            <i class="bi bi-arrow-repeat action-icon" @onclick="ReloadRecentBenches" title="Reload Recent Benches file"></i>
+            <i class="bi bi-pencil action-icon" @onclick="OnEditRecentBenchesFileClick" title="Edit Recent Benches file"></i>
+            <i class="bi bi-arrow-repeat action-icon" @onclick="OnReloadRecentBenchesClick" title="Reload Recent Benches file"></i>
         </span>
     </div>
 

--- a/src/WpfBlazor/Pages/RecentPage.razor
+++ b/src/WpfBlazor/Pages/RecentPage.razor
@@ -1,9 +1,5 @@
 @page "/recent"
 @using WpfBlazor.Components
-@inject IRecentBenchesLoader RecentBenchesLoader
-@inject ILogger<RecentPage> Logger
-@inject IBenchFilePathProvider BenchFilePathProvider
-@inject NavigationManager NavigationManager
 
 <h3>Recent Benches</h3>
 

--- a/src/WpfBlazor/Pages/RecentPage.razor
+++ b/src/WpfBlazor/Pages/RecentPage.razor
@@ -20,9 +20,7 @@ else
     <ul>
         @foreach (var bench in RecentBenches)
         {
-            <li @onclick="() => OnRecentBenchClick(bench)">
-                @bench.BenchLabel (@bench.LastOpened)
-            </li>
+            <RecentBenchView RecentBench="bench" />
         }
     </ul>
 }

--- a/src/WpfBlazor/Pages/RecentPage.razor
+++ b/src/WpfBlazor/Pages/RecentPage.razor
@@ -1,4 +1,34 @@
-﻿@page "/recent"
+@page "/recent"
 @using WpfBlazor.Components
+@inject IRecentBenchesLoader RecentBenchesLoader
+@inject ILogger<RecentPage> Logger
+@inject IBenchFilePathProvider BenchFilePathProvider
+@inject NavigationManager NavigationManager
 
-<h3>RecentPage</h3>
+<h3>Recent Benches</h3>
+
+@if (IsLoading)
+{
+    <p>Loading...</p>
+}
+else if (!string.IsNullOrEmpty(ErrorMessage))
+{
+    <p class="text-danger">@ErrorMessage</p>
+}
+else if (RecentBenches.Count == 0)
+{
+    <p>No recent benches available</p>
+}
+else
+{
+    <ul>
+        @foreach (var bench in RecentBenches)
+        {
+            <li @onclick="() => OnRecentBenchClick(bench)">
+                @bench.BenchLabel (@bench.LastOpened)
+            </li>
+        }
+    </ul>
+}
+
+<button class="btn btn-primary" @onclick="RefreshRecentBenches">Refresh</button>

--- a/src/WpfBlazor/Pages/RecentPage.razor.cs
+++ b/src/WpfBlazor/Pages/RecentPage.razor.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.AspNetCore.Components;
+using K0x.Workbench.RecentBenches.Abstractions;
+using K0x.Workbench.RecentBenches.Abstractions.Models;
+using K0x.Workbench.DataStorage.Abstractions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Components;
 
 namespace WpfBlazor.Pages;
 
@@ -7,14 +11,60 @@ public partial class RecentPage : ComponentBase
 {
     [Inject]
     private ILogger<RecentPage> Logger { get; set; } = default!;
+    [Inject]
+    private IRecentBenchesLoader RecentBenchesLoader { get; set; } = default!;
+    [Inject]
+    private IBenchFilePathProvider BenchFilePathProvider { get; set; } = default!;
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    private List<RecentBench> RecentBenches { get; set; } = new();
+    private bool IsLoading { get; set; }
+    private string? ErrorMessage { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         Logger.LogTrace("OnInitializedAsync START.");
 
-        await base.OnInitializedAsync();
+        await LoadRecentBenchesAsync();
 
         Logger.LogTrace("OnInitializedAsync END.");
     }
 
+    private async Task LoadRecentBenchesAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            var benches = await RecentBenchesLoader.GetRecentBenchesAsync();
+            RecentBenches = benches.OrderByDescending(b => b.LastOpened).ToList();
+
+            if (RecentBenches.Count == 0)
+            {
+                Logger.LogInformation("No recent benches available");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading recent benches");
+            ErrorMessage = "An error occurred while loading recent benches.";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private async Task RefreshRecentBenches()
+    {
+        await LoadRecentBenchesAsync();
+    }
+
+    private void OnRecentBenchClick(RecentBench bench)
+    {
+        BenchFilePathProvider.FilePath = bench.FilePath;
+        NavigationManager.NavigateTo("/bench");
+    }
 }

--- a/src/WpfBlazor/Pages/RecentPage.razor.cs
+++ b/src/WpfBlazor/Pages/RecentPage.razor.cs
@@ -2,20 +2,24 @@ using K0x.Workbench.DataStorage.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
+using System.Windows;
 
 namespace WpfBlazor.Pages;
 
 public partial class RecentPage : ComponentBase
 {
     [Inject]
+    IBenchFilePathProvider BenchFilePathProvider { get; set; } = default!;
+    [Inject]
     private ILogger<RecentPage> Logger { get; set; } = default!;
     [Inject]
-    private IRecentBenchesLoader RecentBenchesLoader { get; set; } = default!;
-    [Inject]
-    private IBenchFilePathProvider BenchFilePathProvider { get; set; } = default!;
-    [Inject]
     private NavigationManager NavigationManager { get; set; } = default!;
+    [Inject]
+    private IRecentBenchesFilePathProvider RecentBenchesFilePathProvider { get; set; } = default!;
+    [Inject]
+    private IRecentBenchesLoader RecentBenchesLoader { get; set; } = default!;
 
     private List<RecentBench> RecentBenches { get; set; } = new();
     private bool IsLoading { get; set; }
@@ -56,7 +60,7 @@ public partial class RecentPage : ComponentBase
         }
     }
 
-    private async Task RefreshRecentBenches()
+    private async Task ReloadRecentBenches()
     {
         await LoadRecentBenchesAsync();
     }
@@ -65,5 +69,35 @@ public partial class RecentPage : ComponentBase
     {
         BenchFilePathProvider.FilePath = bench.FilePath;
         NavigationManager.NavigateTo("/bench");
+    }
+        
+   private void EditRecentBenchesFile(MouseEventArgs e)
+    {
+        string? recentBenchesFilePath = RecentBenchesFilePathProvider.GetFilePath();
+        if (!string.IsNullOrEmpty(recentBenchesFilePath))
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = recentBenchesFilePath,
+                UseShellExecute = true
+            };
+            try
+            {
+                System.Diagnostics.Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, $"Error opening file for editing: {recentBenchesFilePath}");
+
+                MessageBox.Show(
+                    $"Error opening file for editing: {recentBenchesFilePath}\n"
+                    + $"{ex.GetType()}\n"
+                    + "\n"
+                    + $"{ex.Message}\n",
+                    caption: "Error opening file for editing",
+                    button: MessageBoxButton.OK,
+                    icon: MessageBoxImage.Error);
+            }
+        }
     }
 }

--- a/src/WpfBlazor/Pages/RecentPage.razor.cs
+++ b/src/WpfBlazor/Pages/RecentPage.razor.cs
@@ -1,9 +1,8 @@
+using K0x.Workbench.DataStorage.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions;
 using K0x.Workbench.RecentBenches.Abstractions.Models;
-using K0x.Workbench.DataStorage.Abstractions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Components;
 
 namespace WpfBlazor.Pages;
 

--- a/src/WpfBlazor/Pages/RecentPage.razor.cs
+++ b/src/WpfBlazor/Pages/RecentPage.razor.cs
@@ -60,7 +60,7 @@ public partial class RecentPage : ComponentBase
         }
     }
 
-    private async Task ReloadRecentBenches()
+    private async Task OnReloadRecentBenchesClick()
     {
         await LoadRecentBenchesAsync();
     }
@@ -70,8 +70,8 @@ public partial class RecentPage : ComponentBase
         BenchFilePathProvider.FilePath = bench.FilePath;
         NavigationManager.NavigateTo("/bench");
     }
-        
-   private void EditRecentBenchesFile(MouseEventArgs e)
+
+   private void OnEditRecentBenchesFileClick(MouseEventArgs e)
     {
         string? recentBenchesFilePath = RecentBenchesFilePathProvider.GetFilePath();
         if (!string.IsNullOrEmpty(recentBenchesFilePath))

--- a/src/WpfBlazor/Pages/RecentPage.razor.css
+++ b/src/WpfBlazor/Pages/RecentPage.razor.css
@@ -1,0 +1,27 @@
+﻿.action-icon {
+    cursor: pointer;
+    margin-left: 2px;
+    color: blue;
+    position: relative;
+}
+
+.bench-path {
+    display: block;
+    font-size: smaller;
+    color: gray;
+}
+
+.btn-small {
+    padding: 2px 5px; /* Adjusted padding to make the outline tighter */
+    font-size: 0.875rem;
+}
+
+.container {
+    margin: 5px;
+}
+
+.horizontal-separator {
+    border: none;
+    border-top: 1px solid #ccc;
+    margin: 10px 0;
+}


### PR DESCRIPTION
Fixes #15

Enhance the `RecentPage` to display a list of `RecentBench` items sorted by `LastOpened` property in descending order.

* **UI Changes**:
  - Add a list to display `RecentBench` items.
  - Add a refresh button to reload the list of recent benches.
  - Add error handling to display error messages directly in the `RecentPage` UI.
  - Add a message "No recent benches available" when the list is empty.
  - Display a loading indicator when `IsLoading` is `true`.

* **Logic Changes**:
  - Inject `IRecentBenchesLoader` to load recent benches.
  - Inject `ILogger<RecentPage>` to log errors and messages.
  - Inject `IBenchFilePathProvider` and `NavigationManager` into the `RecentPage` component.
  - Add a method to load and sort `RecentBench` items by `LastOpened` property in descending order.
  - Add a method to handle errors and display error messages in the UI.
  - Add a method to handle the refresh button click event to reload the list of recent benches.
  - Add a method to handle the click event on a `RecentBench` item to set the `FilePath` property of the `IBenchFilePathProvider` and navigate to the `BenchPage`.
  - Add a boolean property `IsLoading` to the `RecentPage` component to track the loading state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bryanknox/k0x-workbench/pull/20?shareId=4ba55cac-1826-47d6-b229-c7cadf6a9c23).